### PR TITLE
chore: update CI workflows to install JDK 21

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'jetbrains'
-          java-version: '17'
+          java-version: '21'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'jetbrains'
-          java-version: '17'
+          java-version: '21'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'jetbrains'
-          java-version: '17'
+          java-version: '21'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'jetbrains'
-          java-version: '17'
+          java-version: '21'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Updated the java-version from '17' to '21' in all GitHub Actions workflows to match the project's toolchain requirements and improve CI performance.

Fixes #160

---
*PR created automatically by Jules for task [17575429252576055542](https://jules.google.com/task/17575429252576055542) started by @MessiasLima*