### PR TITLE
chore: centralize library version in libs.versions.toml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,7 @@ jobs:
         run: |
           git fetch
           git checkout main
-          sed -i '' -E 's/version = "[0-9]+\.[0-9]+\.[0-9]+"/version = "${{ github.ref_name }}"/g' build.gradle.kts
-          sed -i '' -E 's/version = "[0-g]+\.[0-9]+\.[0-9]+"/version = "${{ github.ref_name }}"/g' umami/build.gradle.kts
-          sed -i '' -E 's/version = "[0-g]+\.[0-9]+\.[0-9]+"/version = "${{ github.ref_name }}"/g' umami-api/build.gradle.kts
+          sed -i '' -E 's/umami = "[0-9]+\.[0-9]+\.[0-9]+"/umami = "${{ github.ref_name }}"/g' gradle/libs.versions.toml
 
       - name: Archive previous documentation version
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,10 +28,8 @@ dependencies {
     kover(project(":umami-api"))
 }
 
-val version = libs.versions.umami.get()
-
 dokka {
-    val currentVersion = version
+    val currentVersion = libs.versions.umami.get()
 
     dokkaPublications.html {
         outputDirectory.set(projectDir.resolve("docs/reference"))
@@ -50,7 +48,7 @@ dokka {
         }
 
         versioning {
-            version.set(currentVersion)
+            version.set(libs.versions.umami.get())
             olderVersionsDir.set(projectDir.resolve("docs/versions"))
             renderVersionsNavigationOnAllPages.set(true)
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,6 @@ dependencies {
 }
 
 dokka {
-    val currentVersion = libs.versions.umami.get()
-
     dokkaPublications.html {
         outputDirectory.set(projectDir.resolve("docs/reference"))
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     kover(project(":umami-api"))
 }
 
-val version = "0.4.0"
+val version = libs.versions.umami.get()
 
 dokka {
     val currentVersion = version

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ kotest = "6.0.7"
 kotlin = "2.2.21"
 ktor = "3.3.3"
 maven-publish = "0.35.0"
+umami = "0.4.0"
 
 [libraries]
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }

--- a/umami-api/build.gradle.kts
+++ b/umami-api/build.gradle.kts
@@ -92,11 +92,9 @@ android {
     }
 }
 
-val version = libs.versions.umami.get()
-
 mavenPublishing {
     publishToMavenCentral(true)
-    coordinates(groupId = "dev.appoutlet", artifactId = "umami-api", version = version)
+    coordinates(groupId = "dev.appoutlet", artifactId = "umami-api", version = libs.versions.umami.get())
 
     pom {
         name = "umami-api"
@@ -131,7 +129,7 @@ mavenPublishing {
 }
 
 dokka {
-    val currentVersion = version
+    val currentVersion = libs.versions.umami.get()
 
     dokkaPublications.html {
         outputDirectory.set(projectDir.resolve("docs/reference/api"))
@@ -150,7 +148,7 @@ dokka {
         }
 
         versioning {
-            version.set(currentVersion)
+            version.set(libs.versions.umami.get())
             olderVersionsDir.set(projectDir.resolve("docs/versions"))
             renderVersionsNavigationOnAllPages.set(true)
         }

--- a/umami-api/build.gradle.kts
+++ b/umami-api/build.gradle.kts
@@ -92,7 +92,7 @@ android {
     }
 }
 
-val version = "0.4.0"
+val version = libs.versions.umami.get()
 
 mavenPublishing {
     publishToMavenCentral(true)

--- a/umami-api/build.gradle.kts
+++ b/umami-api/build.gradle.kts
@@ -129,8 +129,6 @@ mavenPublishing {
 }
 
 dokka {
-    val currentVersion = libs.versions.umami.get()
-
     dokkaPublications.html {
         outputDirectory.set(projectDir.resolve("docs/reference/api"))
     }

--- a/umami/build.gradle.kts
+++ b/umami/build.gradle.kts
@@ -160,8 +160,6 @@ mavenPublishing {
 }
 
 dokka {
-    val currentVersion = libs.versions.umami.get()
-
     dokkaPublications.html {
         outputDirectory.set(projectDir.resolve("docs/reference"))
     }

--- a/umami/build.gradle.kts
+++ b/umami/build.gradle.kts
@@ -123,11 +123,9 @@ android {
     }
 }
 
-val version = libs.versions.umami.get()
-
 mavenPublishing {
     publishToMavenCentral(true)
-    coordinates(groupId = "dev.appoutlet", artifactId = "umami", version = version)
+    coordinates(groupId = "dev.appoutlet", artifactId = "umami", version = libs.versions.umami.get())
 
     pom {
         name = "umami"
@@ -162,7 +160,7 @@ mavenPublishing {
 }
 
 dokka {
-    val currentVersion = version
+    val currentVersion = libs.versions.umami.get()
 
     dokkaPublications.html {
         outputDirectory.set(projectDir.resolve("docs/reference"))
@@ -181,7 +179,7 @@ dokka {
         }
 
         versioning {
-            version.set(currentVersion)
+            version.set(libs.versions.umami.get())
             olderVersionsDir.set(projectDir.resolve("docs/versions"))
             renderVersionsNavigationOnAllPages.set(true)
         }

--- a/umami/build.gradle.kts
+++ b/umami/build.gradle.kts
@@ -123,7 +123,7 @@ android {
     }
 }
 
-val version = "0.4.0"
+val version = libs.versions.umami.get()
 
 mavenPublishing {
     publishToMavenCentral(true)


### PR DESCRIPTION
This PR centralizes the library version in `gradle/libs.versions.toml`.

Key changes:
- Added `umami = "0.4.0"` to `gradle/libs.versions.toml`.
- Replaced hardcoded `val version = "0.4.0"` in root, `umami/`, and `umami-api/` `build.gradle.kts` files with `libs.versions.umami.get()`.
- Updated `.github/workflows/publish.yml` to target `gradle/libs.versions.toml` for version updates during release.
- Fixed a regex typo in the publish workflow (`[0-g]` to `[0-9]`).

Verified locally with `./gradlew detekt allTests koverVerify`. Core modules pass tests. Sample modules had pre-existing failures unrelated to these changes.

Fixes #158

---
*PR created automatically by Jules for task [16407086255060147485](https://jules.google.com/task/16407086255060147485) started by @MessiasLima*