### PR TITLE
feat: add API key authentication for Umami Cloud

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -18,7 +18,7 @@ val authApi = api.auth()
 
 ## Logging In
 
-There are two primary ways to log in using the library: by providing a username and password directly, or by using an `Auth.Login.Request` object.
+There are three primary ways to log in using the library: by providing a username and password directly, using an `Auth.Login.Request` object, or by using an API key (ideal for Umami Cloud).
 
 ### Using Username and Password
 
@@ -52,6 +52,21 @@ val loginRequest = Auth.Login.Request(
 val loginResponse = authApi.login(loginRequest)
 println("Login successful!")
 ```
+
+### Using an API Key (Umami Cloud)
+
+Umami Cloud and some self-hosted instances support authentication via an API key. This method doesn't require a username or password and is the recommended way to authenticate with Umami Cloud.
+
+**Example:**
+```kotlin
+// Assuming 'authApi' is an instance of Auth
+val loginResponse = authApi.login("your-umami-api-key")
+
+println("Authenticated with API key! User: ${loginResponse.user.username}")
+```
+
+!!! info "API Key Validation"
+    When you log in with an API key, the library automatically calls the `GET /api/me` endpoint to verify that the key is valid.
 
 ### Login Response
 

--- a/umami-api/src/commonMain/kotlin/dev/appoutlet/umami/api/Auth.kt
+++ b/umami-api/src/commonMain/kotlin/dev/appoutlet/umami/api/Auth.kt
@@ -9,7 +9,7 @@ import io.ktor.http.HttpHeaders
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-private const val UmamiApiKeyHeader = "x-umami-api-key"
+internal const val UMAMI_API_KEY_HEADER = "x-umami-api-key"
 
 /**
  * Provides authentication functionalities for interacting with the Umami API.
@@ -63,13 +63,14 @@ class Auth(private val api: UmamiApi) {
      * @param apiKey The API key to use for authentication.
      * @return A [Session] object containing the user's session details.
      */
+    @Suppress("TooGenericExceptionCaught")
     suspend fun login(apiKey: String): Session {
-        api.headers.put(UmamiApiKeyHeader, apiKey)
+        api.headers.put(UMAMI_API_KEY_HEADER, apiKey)
 
         return try {
             api.me().getSession()
-        } catch (exception: Throwable) {
-            api.headers.remove(UmamiApiKeyHeader)
+        } catch (exception: Exception) {
+            api.headers.remove(UMAMI_API_KEY_HEADER)
             throw exception
         }
     }
@@ -89,7 +90,7 @@ class Auth(private val api: UmamiApi) {
             api.headers.remove(HttpHeaders.Authorization)
         }
 
-        api.headers.remove(UmamiApiKeyHeader)
+        api.headers.remove(UMAMI_API_KEY_HEADER)
     }
 
     /**

--- a/umami-api/src/commonMain/kotlin/dev/appoutlet/umami/api/Auth.kt
+++ b/umami-api/src/commonMain/kotlin/dev/appoutlet/umami/api/Auth.kt
@@ -9,6 +9,8 @@ import io.ktor.http.HttpHeaders
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+private const val UmamiApiKeyHeader = "x-umami-api-key"
+
 /**
  * Provides authentication functionalities for interacting with the Umami API.
  * This class handles user login, logout, and token verification.
@@ -55,12 +57,39 @@ class Auth(private val api: UmamiApi) {
     }
 
     /**
-     * Logs out the current user by sending a logout request to the Umami API
-     * and removing the authorization header.
+     * Logs in a user using an API key.
+     * This method is intended for use with Umami Cloud or instances where API key authentication is enabled.
+     *
+     * @param apiKey The API key to use for authentication.
+     * @return A [Session] object containing the user's session details.
+     */
+    suspend fun login(apiKey: String): Session {
+        api.headers.put(UmamiApiKeyHeader, apiKey)
+
+        return try {
+            api.me().getSession()
+        } catch (exception: Throwable) {
+            api.headers.remove(UmamiApiKeyHeader)
+            throw exception
+        }
+    }
+
+    /**
+     * Logs out the current user.
+     *
+     * If an authorization token is present, it sends a logout request to the Umami API
+     * and removes both the authorization and API key headers.
+     *
+     * If no authorization token is present (e.g., when using an API key for Umami Cloud),
+     * it only removes the API key header without calling the logout endpoint.
      */
     suspend fun logout() {
-        api.httpClient.post(Api.Auth.Logout())
-        api.headers.remove(HttpHeaders.Authorization)
+        if (api.headers.get(HttpHeaders.Authorization) != null) {
+            api.httpClient.post(Api.Auth.Logout())
+            api.headers.remove(HttpHeaders.Authorization)
+        }
+
+        api.headers.remove(UmamiApiKeyHeader)
     }
 
     /**

--- a/umami-api/src/commonMain/kotlin/dev/appoutlet/umami/api/Auth.kt
+++ b/umami-api/src/commonMain/kotlin/dev/appoutlet/umami/api/Auth.kt
@@ -66,6 +66,7 @@ class Auth(private val api: UmamiApi) {
     @Suppress("TooGenericExceptionCaught")
     suspend fun login(apiKey: String): Session {
         api.headers.put(UMAMI_API_KEY_HEADER, apiKey)
+        api.headers.remove(HttpHeaders.Authorization)
 
         return try {
             api.me().getSession()

--- a/umami-api/src/commonTest/kotlin/dev/appoutlet/umami/api/AuthTest.kt
+++ b/umami-api/src/commonTest/kotlin/dev/appoutlet/umami/api/AuthTest.kt
@@ -76,19 +76,82 @@ class AuthTest {
     }
 
     @Test
-    fun `logout should remove auth header`() = runTest {
+    fun `login with API key should return success response and set x-umami-api-key header`() = runTest {
+        val fixtureApiKey = "test-api-key"
+        val mockLoginResponse = Session(
+            token = "unused-token",
+            user = testUser
+        )
+
+        val api = getUmamiApiInstance(
+            "/api/me" to { request ->
+                request.url.encodedPath shouldBe "/api/me"
+                respond(mockLoginResponse)
+            }
+        )
+
+        val response = api.auth().login(fixtureApiKey)
+
+        response shouldBe mockLoginResponse
+        api.headers.get("x-umami-api-key") shouldBe fixtureApiKey
+    }
+
+    @Test
+    fun `login with invalid API key should remove header and throw exception`() = runTest {
+        val fixtureApiKey = "invalid-api-key"
+
+        val api = getUmamiApiInstance(
+            "/api/me" to { _ ->
+                respond(status = HttpStatusCode.Unauthorized, content = "")
+            }
+        )
+
+        try {
+            api.auth().login(fixtureApiKey)
+        } catch (exception: Throwable) {
+            // Success
+        }
+
+        api.headers.get("x-umami-api-key") shouldBe null
+    }
+
+    @Test
+    fun `logout with authorization header should call logout endpoint and remove headers`() = runTest {
+        var logoutCalled = false
         val api = getUmamiApiInstance(
             "/api/auth/logout" to { request ->
                 request.url.encodedPath shouldBe "/api/auth/logout"
+                logoutCalled = true
                 respond(status = HttpStatusCode.OK, content = "")
             }
         )
-        // Set a dummy token to ensure it gets removed
+        // Set dummy headers
         api.headers.put(HttpHeaders.Authorization, "Bearer $testToken")
+        api.headers.put("x-umami-api-key", "some-key")
 
         api.auth().logout()
 
+        logoutCalled shouldBe true
         api.headers.get(HttpHeaders.Authorization) shouldBe null
+        api.headers.get("x-umami-api-key") shouldBe null
+    }
+
+    @Test
+    fun `logout without authorization header should only remove x-umami-api-key header`() = runTest {
+        var logoutCalled = false
+        val api = getUmamiApiInstance(
+            "/api/auth/logout" to { _ ->
+                logoutCalled = true
+                respond(status = HttpStatusCode.OK, content = "")
+            }
+        )
+        // Set dummy API key header, but no Authorization header
+        api.headers.put("x-umami-api-key", "some-key")
+
+        api.auth().logout()
+
+        logoutCalled shouldBe false
+        api.headers.get("x-umami-api-key") shouldBe null
     }
 
     @Test

--- a/umami-api/src/commonTest/kotlin/dev/appoutlet/umami/api/AuthTest.kt
+++ b/umami-api/src/commonTest/kotlin/dev/appoutlet/umami/api/AuthTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 
@@ -93,7 +94,7 @@ class AuthTest {
         val response = api.auth().login(fixtureApiKey)
 
         response shouldBe mockLoginResponse
-        api.headers.get("x-umami-api-key") shouldBe fixtureApiKey
+        api.headers.get(UMAMI_API_KEY_HEADER) shouldBe fixtureApiKey
     }
 
     @Test
@@ -106,13 +107,11 @@ class AuthTest {
             }
         )
 
-        try {
+        assertFailsWith<Exception> {
             api.auth().login(fixtureApiKey)
-        } catch (exception: Throwable) {
-            // Success
         }
 
-        api.headers.get("x-umami-api-key") shouldBe null
+        api.headers.get(UMAMI_API_KEY_HEADER) shouldBe null
     }
 
     @Test
@@ -127,13 +126,13 @@ class AuthTest {
         )
         // Set dummy headers
         api.headers.put(HttpHeaders.Authorization, "Bearer $testToken")
-        api.headers.put("x-umami-api-key", "some-key")
+        api.headers.put(UMAMI_API_KEY_HEADER, "some-key")
 
         api.auth().logout()
 
         logoutCalled shouldBe true
         api.headers.get(HttpHeaders.Authorization) shouldBe null
-        api.headers.get("x-umami-api-key") shouldBe null
+        api.headers.get(UMAMI_API_KEY_HEADER) shouldBe null
     }
 
     @Test
@@ -146,12 +145,12 @@ class AuthTest {
             }
         )
         // Set dummy API key header, but no Authorization header
-        api.headers.put("x-umami-api-key", "some-key")
+        api.headers.put(UMAMI_API_KEY_HEADER, "some-key")
 
         api.auth().logout()
 
         logoutCalled shouldBe false
-        api.headers.get("x-umami-api-key") shouldBe null
+        api.headers.get(UMAMI_API_KEY_HEADER) shouldBe null
     }
 
     @Test

--- a/umami-api/src/commonTest/kotlin/dev/appoutlet/umami/api/AuthTest.kt
+++ b/umami-api/src/commonTest/kotlin/dev/appoutlet/umami/api/AuthTest.kt
@@ -87,6 +87,7 @@ class AuthTest {
         val api = getUmamiApiInstance(
             "/api/me" to { request ->
                 request.url.encodedPath shouldBe "/api/me"
+                request.headers[UMAMI_API_KEY_HEADER] shouldBe fixtureApiKey
                 respond(mockLoginResponse)
             }
         )
@@ -133,6 +134,27 @@ class AuthTest {
         logoutCalled shouldBe true
         api.headers.get(HttpHeaders.Authorization) shouldBe null
         api.headers.get(UMAMI_API_KEY_HEADER) shouldBe null
+    }
+
+    @Test
+    fun `login with API key should remove existing authorization header`() = runTest {
+        val fixtureApiKey = "test-api-key"
+        val mockLoginResponse = Session(
+            token = "unused-token",
+            user = testUser
+        )
+
+        val api = getUmamiApiInstance(
+            "/api/me" to { _ ->
+                respond(mockLoginResponse)
+            }
+        )
+        api.headers.put(HttpHeaders.Authorization, "Bearer $testToken")
+
+        api.auth().login(fixtureApiKey)
+
+        api.headers.get(HttpHeaders.Authorization) shouldBe null
+        api.headers.get(UMAMI_API_KEY_HEADER) shouldBe fixtureApiKey
     }
 
     @Test


### PR DESCRIPTION
This PR implements API key authentication for Umami Cloud.

Key changes:
- Added a `login(apiKey: String): Session` overload to the `Auth` class.
- The provided API key is stored in the `x-umami-api-key` header.
- The `login` method validates the API key by calling `GET /api/me`.
- If validation fails, the header is removed and the exception is propagated.
- Updated `logout()` to check for the `Authorization` header before hitting the `/api/auth/logout` endpoint, avoiding 500 errors on the server when using only an API key.
- Added unit tests covering successful/failed API key login and various logout scenarios.

Fixes #162

---
*PR created automatically by Jules for task [7642080986388603415](https://jules.google.com/task/7642080986388603415) started by @MessiasLima*