### PR TITLE
Bump Android compileSdk and targetSdk to 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 agp = "8.13.0"
 androidx-activityCompose = "1.13.0"
-android-compileSdk = "36"
+android-compileSdk = "37"
 android-minSdk = "28"
-android-targetSdk = "36"
+android-targetSdk = "37"
 compose = "1.11.1"
 coroutines = "1.11.0"
 detekt = "1.23.8"


### PR DESCRIPTION
This change bumps the Android compileSdk and targetSdk from version 36 to 37 in the `gradle/libs.versions.toml` file. All Android modules in the repository reference these versions through the Gradle version catalog. 

Verified the changes by:
1. Confirming the updated values in `gradle/libs.versions.toml`.
2. Running `./gradlew :umami:assemble :umami-api:assemble :sample:simple-compose-app:composeApp:assembleDebug`, which succeeded.
3. Running unit tests for `:umami` and `:umami-api` modules, all of which passed.

Note: A symbolic link was created in the environment to map `android-37.0` to `android-37` to resolve a Gradle build issue finding the SDK platform.

Fixes #220

---
*PR created automatically by Jules for task [284223037387319997](https://jules.google.com/task/284223037387319997) started by @MessiasLima*