### PR TITLE
Decreasing minSdk to 23

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "9.2.1"
 activityCompose = "1.13.0"
 android-compileSdk = "37"
-android-minSdk = "28"
+android-minSdk = "23"
 android-targetSdk = "37"
 compose = "1.11.1"
 coroutines = "1.11.0"


### PR DESCRIPTION
This PR decreases minSdk to 23, which makes it possible to use the library in Android apps without them requiring 28 minSdk. (Supposedly, 6.5% of devices are still running on SDK versions lower than 28.)

I tried to build the project, and the minimum version for which the build succeeded is 23 due to Jetpack Compose dependency, however this might be further lowered by utilizing different minSdk for the library and the sample app. I haven't made this change for the simplicity of the PR, and the reason that most apps will in practice require minSdk 23+ due to their dependencies.